### PR TITLE
add package.json for NPM publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "color_pals",
+  "version": "1.0.0",
+  "description": "A collection of curated color palettes",
+  "main": "palettes.json",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ronikaufman/color_pals.git"
+  },
+  "keywords": [
+    "color",
+    "colour",
+    "generative",
+    "art",
+    "palettes"
+  ],
+  "author": "Roni Kaufmann",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ronikaufman/color_pals/issues"
+  },
+  "homepage": "https://github.com/ronikaufman/color_pals#readme"
+}


### PR DESCRIPTION
As mentioned i added a `package.json`.

All you need to do once this is merged is: `git pull && npm publish`

If you don't have an NPM account you need to have one: https://www.npmjs.com/
Alternatively I can publish it, but I think you should be the owner of this.

In the future, you can just bump up the number in the package.json and run `npm publish` again.

Others will be able to do something like `import colors from "color_pals"`