### PR TITLE
Add blender mode

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -13,6 +13,26 @@ function makePalettes(palettes) {
   }
 }
 
+function getFixedPointFromHex(hexString) {
+  let asFloat = parseInt(hexString, 16) / 255
+  return parseFloat(asFloat.toFixed(3));
+}
+
+function getBlenderColor(hexString) {
+  let hex = hexString.substring(1);
+  return [
+    getFixedPointFromHex(hex.slice(0, 2)), // red
+    getFixedPointFromHex(hex.slice(2, 4)), // green
+    getFixedPointFromHex(hex.slice(4, 6)), // blue
+    1, // alpha
+  ]
+}
+
+function isBlenderModeActive() {
+  let urlParams = new URLSearchParams(window.location.search);
+  return urlParams.has("blender");
+}
+
 function createPalette(p) {
   let palettep5 = new p5((sketch) => {
     sketch.setup = () => {
@@ -45,11 +65,24 @@ function createPalette(p) {
       sketch.rect(sw/2, sw/2, canvas.width-sw, canvas.height-sw, 9);
       canvas.parent(container);
 
-      let codeString = "[\"";
-      for (let c of p.colors) {
-        codeString += c + "\", \"";
+      let codeString;
+      if (isBlenderModeActive()) {
+        // write four-tuple float colors
+        codeString = "";
+        for (let c of p.colors) {
+          codeString += "[";
+          codeString += getBlenderColor(c);
+          codeString += "] ";
+        }
+      } else {
+        // write hex colors
+        codeString = "[\"";
+        for (let c of p.colors) {
+          codeString += c + "\", \"";
+        }
+        codeString = codeString.substring(0, codeString.length-3) + "]";
       }
-      codeString = codeString.substring(0, codeString.length-3) + "]";
+
       let codeP = sketch.createP(codeString);
       codeP.class("code");
       //codeP.style("width", (divWidth-40)+"px");

--- a/sketch.js
+++ b/sketch.js
@@ -14,8 +14,9 @@ function makePalettes(palettes) {
 }
 
 function getFixedPointFromHex(hexString) {
-  let asFloat = parseInt(hexString, 16) / 255
-  return parseFloat(asFloat.toFixed(3));
+  let rawFloat = parseInt(hexString, 16) / 255;
+  let gammaCorrectedFloat = Math.pow(rawFloat, 2.2);
+  return parseFloat(gammaCorrectedFloat.toFixed(3));
 }
 
 function getBlenderColor(hexString) {


### PR DESCRIPTION
When you add the query string "blender" to the url, https://ronikaufman.github.io/color_pals/?blender, the colors will be output as four float values instead of hex strings. This allows you to copy and paste directly into blender's colour inputs.

In blender you can hover your mouse over one of these colour swatches and simply press ctrl-v without having to open any further dialogues or input any text.

![image](https://user-images.githubusercontent.com/3427072/224477024-3756dfe0-5a29-41f3-8dad-278d432b95dd.png)

The page with blender mode enabled:

![image](https://user-images.githubusercontent.com/3427072/224476963-55464127-08a8-44c8-9aa1-21981e5f6ac6.png)
